### PR TITLE
Compute shape metrics

### DIFF
--- a/None
+++ b/None
@@ -1,5 +1,0 @@
-2025-08-14 01:04:16,223 [INFO] Running computeinstances command
-2025-08-14 01:04:19,586 [INFO] success: 9/9, failures: 0/9
-2025-08-14 01:04:19,806 [INFO] Converted 9 files to tmp/attributed_merged_polygons.parquet
-2025-08-14 01:04:19,806 [INFO] Total features: 4344
-2025-08-14 01:04:19,806 [INFO] Completed computeinstances command

--- a/None
+++ b/None
@@ -1,0 +1,5 @@
+2025-08-14 01:04:16,223 [INFO] Running computeinstances command
+2025-08-14 01:04:19,586 [INFO] success: 9/9, failures: 0/9
+2025-08-14 01:04:19,806 [INFO] Converted 9 files to tmp/attributed_merged_polygons.parquet
+2025-08-14 01:04:19,806 [INFO] Total features: 4344
+2025-08-14 01:04:19,806 [INFO] Completed computeinstances command

--- a/configs/example-config.yaml
+++ b/configs/example-config.yaml
@@ -29,3 +29,8 @@ log_file: None #logs/instancemaker.log  # log file
 tile_geojson: data/zambia_tiles.geojson # geojson containing tile layout
 merged_polygon_dir: tmp/merged_polygons/ # directory to save the merged polygons
 merged_parquet_file: tmp/merged_polygons.parquet # output geoparquet
+
+# ComputeInstances parameters
+attributed_merged_polygon_dir: tmp/attributed_merged_polygons/ # directory to save the attributed merged polygons
+attributed_merged_parquet_file: tmp/attributed_merged_polygons.parquet # output geoparquet
+area_crs: "ESRI:102022" # projection CRS for shape metrics

--- a/src/instancemaker/__init__.py
+++ b/src/instancemaker/__init__.py
@@ -1,3 +1,4 @@
 from .makeinstances import *
 from .mergeinstances import *
+from .computeinstances import *
 from .utils import *

--- a/src/instancemaker/cli.py
+++ b/src/instancemaker/cli.py
@@ -4,7 +4,7 @@ import click
 from pathlib import Path
 import numpy as np
 import pandas as pd
-from instancemaker import MakeInstances, MergeInstances
+from instancemaker import MakeInstances, MergeInstances, compute_shape_metrics_parallel
 from instancemaker.utils import *
 import concurrent.futures
 from functools import partial
@@ -251,6 +251,57 @@ def mergeinstances(config, tile_geojson, polygon_dir, merged_polygon_dir,
         convert_geojson_to_geoparquet(mrgi.merged_polygon_dir,  
                                       merged_parquet_file)
     logging.info("Completed mergeinstances command")
+
+@cli.command()
+
+@click.option('--config', default='configs/example-config.yaml', type=str, 
+              help='Path to config file.')
+@click.option('--merged-polygon-dir', default=None, type=str, 
+              help='Directory for reading merged polygon files.')
+@click.option('--attributed-merged-polygon-dir', default=None, type=str, 
+              help='Output directory for writing attributed merged polygon files.')
+@click.option('--num-workers', default=None, type=int, 
+              help='Number of workers for parallelized processes.')
+@click.option('--attributed-merged-parquet-file', default=None, type=str, 
+              help='Output attributed geoparquet filename.')
+@click.option('--area-crs', default='ESRI:102022', type=str, help='CRS for projection.')
+@click.option('--log-file', default=None, type=str, help='Log file path.')
+
+def computeinstances(config, merged_polygon_dir, attributed_merged_polygon_dir, 
+                     num_workers, attributed_merged_parquet_file, area_crs, log_file):
+    """Run ComputeInstances methods (compute shape metrics on merged polygons)."""
+    # Load config file
+    with open(config, "r") as f:
+        config_data = yaml.safe_load(f)
+
+    # Determine log file: CLI arg takes precedence, else config, else None
+    log_file = get_config_value(log_file, config_data, 'log_file')
+    configure_logging(log_file=log_file)
+    logging.info("Running computeinstances command")
+
+    merged_polygon_dir = get_config_value(merged_polygon_dir, config_data, 
+                                          'merged_polygon_dir')
+    attributed_merged_polygon_dir = get_config_value(attributed_merged_polygon_dir, config_data, 
+                                                     'attributed_merged_polygon_dir')
+    num_workers = get_config_value(num_workers, config_data, 'num_workers')
+    area_crs = get_config_value(area_crs, config_data, 'area_crs')
+
+    attributed_merged_parquet_file = get_config_value(attributed_merged_parquet_file, config_data, 
+                                                      'attributed_merged_parquet_file')
+
+    check_dir([attributed_merged_polygon_dir])
+
+    # compute shape metrics
+    compute_shape_metrics_parallel(merged_polygon_dir, 
+                                   attributed_merged_polygon_dir, 
+                                   area_crs, 
+                                   num_workers)
+
+
+    if attributed_merged_parquet_file:
+        convert_geojson_to_geoparquet(attributed_merged_polygon_dir,  
+                                      attributed_merged_parquet_file)
+    logging.info("Completed computeinstances command")
 
 if __name__ == '__main__':
     cli()

--- a/src/instancemaker/computeinstances.py
+++ b/src/instancemaker/computeinstances.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+import math
+from pathlib import Path
+from concurrent.futures import ProcessPoolExecutor, as_completed
+
+import numpy as np
+import geopandas as gpd
+import glob
+
+import logging
+
+
+def compute_shape_metrics(gdf: gpd.GeoDataFrame, area_crs: str) -> gpd.GeoDataFrame:
+    proj = gdf.to_crs(area_crs)
+    out = gdf.copy()
+    if len(out) == 0:
+        return out
+    # area_m2
+    out['area_m2'] = proj.geometry.area
+    # area_ha
+    out['area_ha'] = out['area_m2'] / 10000.0
+    # perimeter_m
+    out['perimeter_m'] = proj.geometry.length
+
+    A = out['area_m2']
+    P = out['perimeter_m']
+    A_pos = A.where(A > 0, np.nan)
+    P_pos = P.where(P > 0, np.nan)
+    with np.errstate(divide="ignore", invalid="ignore"):
+        out['compactness'] = (4.0 * math.pi * A) / (P ** 2)
+        out['shape_index'] = P / (2.0 * np.sqrt(math.pi * A))
+        out['interior_edge'] = P / A
+        out["fractal_dim"]   = 2.0 * np.log(P_pos) / np.log(A_pos)
+
+    return out
+
+def attribute_shape_metrics(in_path: str, out_path: str, area_crs: str) -> None:
+    gdf = gpd.read_file(in_path)
+    out = compute_shape_metrics(gdf, area_crs)
+    out['tile_id'] = int(Path(in_path).name[4:10])
+    out.to_file(out_path, driver="GeoJSON")
+    return (str(out_path), None, True)
+
+def compute_shape_metrics_parallel(merged_polygon_dir: str, attributed_merged_polygon_dir: str, area_crs: str, num_workers: int) -> None:
+    input_geojsons = glob.glob(merged_polygon_dir + "/*.geojson")
+    output_geojsons = []
+    failures = []
+
+    with ProcessPoolExecutor(max_workers=num_workers) as executor:
+        # Submit all tasks
+        future_to_path = {}
+        for in_path in input_geojsons:
+            out_path = attributed_merged_polygon_dir + "/" + in_path.split("/")[-1]
+            future = executor.submit(attribute_shape_metrics, in_path, out_path, area_crs)
+            future_to_path[future] = (in_path, out_path)
+
+        # Collect results
+        for future in as_completed(future_to_path):
+            in_path, expected_out_path = future_to_path[future]
+            try:
+                out_path, err, flag = future.result()
+                if flag:
+                    output_geojsons.append(out_path)
+                else:
+                    print(f"Error at: {in_path}, {err}")
+                    failures.append((out_path, err))
+            except Exception as exc:
+                print(f"Exception at: {in_path}, {exc}")
+                failures.append((expected_out_path, str(exc)))
+
+    logging.info(f"success: {len(output_geojsons)}/{len(input_geojsons)}, failures: {len(failures)}/{len(input_geojsons)}")

--- a/src/instancemaker/computeinstances.py
+++ b/src/instancemaker/computeinstances.py
@@ -42,6 +42,10 @@ def attribute_shape_metrics(in_path: str, out_path: str, area_crs: str) -> None:
     return (str(out_path), None, True)
 
 def compute_shape_metrics_parallel(merged_polygon_dir: str, attributed_merged_polygon_dir: str, area_crs: str, num_workers: int) -> None:
+    if isinstance(merged_polygon_dir, Path):
+        merged_polygon_dir = str(merged_polygon_dir)
+    if isinstance(attributed_merged_polygon_dir, Path):
+        attributed_merged_polygon_dir = str(attributed_merged_polygon_dir)
     input_geojsons = glob.glob(merged_polygon_dir + "/*.geojson")
     output_geojsons = []
     failures = []

--- a/src/instancemaker/computeinstances.py
+++ b/src/instancemaker/computeinstances.py
@@ -6,7 +6,7 @@ from concurrent.futures import ProcessPoolExecutor, as_completed
 import numpy as np
 import geopandas as gpd
 import glob
-
+from tqdm import tqdm
 import logging
 
 
@@ -59,17 +59,19 @@ def compute_shape_metrics_parallel(merged_polygon_dir: str, attributed_merged_po
             future_to_path[future] = (in_path, out_path)
 
         # Collect results
-        for future in as_completed(future_to_path):
-            in_path, expected_out_path = future_to_path[future]
-            try:
-                out_path, err, flag = future.result()
-                if flag:
-                    output_geojsons.append(out_path)
-                else:
-                    print(f"Error at: {in_path}, {err}")
-                    failures.append((out_path, err))
-            except Exception as exc:
-                print(f"Exception at: {in_path}, {exc}")
-                failures.append((expected_out_path, str(exc)))
+        with tqdm(total=len(input_geojsons), desc="Computing shape metrics") as pbar:
+            for future in as_completed(future_to_path):
+                in_path, expected_out_path = future_to_path[future]
+                try:
+                    out_path, err, flag = future.result()
+                    if flag:
+                        output_geojsons.append(out_path)
+                    else:
+                        print(f"Error at: {in_path}, {err}")
+                        failures.append((out_path, err))
+                except Exception as exc:
+                    print(f"Exception at: {in_path}, {exc}")
+                    failures.append((expected_out_path, str(exc)))
+                pbar.update(1)
 
     logging.info(f"success: {len(output_geojsons)}/{len(input_geojsons)}, failures: {len(failures)}/{len(input_geojsons)}")

--- a/src/instancemaker/computeinstances.py
+++ b/src/instancemaker/computeinstances.py
@@ -78,5 +78,5 @@ def compute_shape_metrics_parallel(
                     failures.append((expected_out_path, str(exc)))
                 pbar.update(1)
 
-    logging.info(f"success: {len(output_geojsons)}/{len(input_geojsons)}, "\ 
+    logging.info(f"success: {len(output_geojsons)}/{len(input_geojsons)}, "
                  f"failures: {len(failures)}/{len(input_geojsons)}")

--- a/src/instancemaker/computeinstances.py
+++ b/src/instancemaker/computeinstances.py
@@ -41,7 +41,11 @@ def attribute_shape_metrics(in_path: str, out_path: str, area_crs: str) -> None:
     out.to_file(out_path, driver="GeoJSON")
     return (str(out_path), None, True)
 
-def compute_shape_metrics_parallel(merged_polygon_dir: str, attributed_merged_polygon_dir: str, area_crs: str, num_workers: int) -> None:
+def compute_shape_metrics_parallel(
+    merged_polygon_dir: str, 
+    attributed_merged_polygon_dir: str, 
+    area_crs: str, num_workers: int
+) -> None:
     if isinstance(merged_polygon_dir, Path):
         merged_polygon_dir = str(merged_polygon_dir)
     if isinstance(attributed_merged_polygon_dir, Path):
@@ -74,4 +78,5 @@ def compute_shape_metrics_parallel(merged_polygon_dir: str, attributed_merged_po
                     failures.append((expected_out_path, str(exc)))
                 pbar.update(1)
 
-    logging.info(f"success: {len(output_geojsons)}/{len(input_geojsons)}, failures: {len(failures)}/{len(input_geojsons)}")
+    logging.info(f"success: {len(output_geojsons)}/{len(input_geojsons)}, "\ 
+                 f"failures: {len(failures)}/{len(input_geojsons)}")

--- a/src/instancemaker/utils.py
+++ b/src/instancemaker/utils.py
@@ -7,6 +7,8 @@ import geopandas as gpd
 import leafmap.leafmap as leafmap
 import pandas as pd
 import glob
+import logging
+
 
 def convert_geojson_to_geoparquet(input_dir, output_file):
     """
@@ -36,8 +38,8 @@ def convert_geojson_to_geoparquet(input_dir, output_file):
     # Save as GeoParquet
     combined_gdf.to_parquet(output_file, index=False)
     
-    print(f"Converted {len(geojson_files)} files to {output_file}")
-    print(f"Total features: {len(combined_gdf)}")
+    logging.info(f"Converted {len(geojson_files)} files to {output_file}")
+    logging.info(f"Total features: {len(combined_gdf)}")
 
 def get_filename(name_template, tile, year, date, suffix=None):
     """


### PR DESCRIPTION
Add Shape Metrics Computation Feature

Summary

This PR adds a shape metrics computation module for polygon instances, enabling calculation of multiple geometric properties such as area, perimeter, compactness, shape index, interior edge ratio, and fractal dimension.

Key Features

New Module: computeinstances.py

Comprehensive Shape Metrics

area_m2 — Area in square meters

area_ha — Area in hectares

perimeter_m — Perimeter in meters

compactness — Shape compactness ratio (4πA / P²)

shape_index — Shape complexity index (P / 2√(πA))

interior_edge — Interior edge ratio (P / A)

fractal_dim — Fractal dimension (2 log(P) / log(A))

Parallel Processing using ProcessPoolExecutor

Progress Tracking with tqdm progress bar

Robust Error Handling with detailed logging

Technical Details

Core Functions

compute_shape_metrics() – Computes metrics for individual GeoDataFrames

attribute_shape_metrics() – Processes individual files and adds tile ID attribution

compute_shape_metrics_parallel() – Parallel processing wrapper with progress tracking

Enhancements

CLI integration for shape metrics computation

Configurable CRS (default: ESRI:102022)

Adjustable worker count for scalability

Benefits

Performance – Significantly faster on large datasets via parallelization

User Experience – Real-time progress feedback

Robustness – Comprehensive error handling for reliable execution

Flexibility – Configurable CRS and processing options

Testing

Verified calculations on sample datasets

Tested parallel execution with different worker settings

Validated results against known geometric properties