### PR TITLE
Fix deprecated unary_union in mergeinstances

### DIFF
--- a/src/instancemaker/mergeinstances.py
+++ b/src/instancemaker/mergeinstances.py
@@ -342,12 +342,19 @@ class MergeInstances:
             logging.warning(f"No polygons found for tile {target_tile}")
             return False
 
+    
+        
         # Combine all polygons
-        logging.debug("Combining polygons from adjacent tiles")
-        all_combine = pd.concat(retrieved_polygons, 
-                                ignore_index=True).unary_union
-        polygons = list(all_combine.geoms)
-        logging.debug(f"Combined into {len(polygons)} polygons")
+        all_combine = pd.concat(
+            retrieved_polygons,
+            ignore_index=True
+        ).geometry.union_all()
+        
+        if all_combine.geom_type == "Polygon":
+            polygons = [all_combine]
+        else:
+            polygons = list(all_combine.geoms)
+
 
         # Assign polygons to tiles
         tile_polygons = {tile['tilename']: [] for tile in adjacent_tiles}


### PR DESCRIPTION
This PR updates the cross-tile merge logic to accommodate recent changes
in Shapely’s geometry API.

In newer versions of Shapely, the `unary_union` attribute is deprecated,
and the recommended replacement is `geometry.union_all()`. In addition,
the union operation may return either a `Polygon` or a `MultiPolygon`,
whereas the previous implementation implicitly assumed a `MultiPolygon`
and accessed `.geoms` unconditionally.

This PR replaces the deprecated `unary_union` call with
`geometry.union_all()` and adds explicit handling for `Polygon` vs
`MultiPolygon` outputs. This prevents tile-level merge failures that
occurred due to the changed return type behavior, and restores stable
cross-tile merging without altering the original merge semantics.

Tested on the Nigeria 2024 configuration: the merge completes
successfully and the merged GeoParquet is generated as expected.
